### PR TITLE
Slot Template Filling Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ The exposed API follows the format defined by Rasa. See [Rasa NLG Servers](https
 The NLG server loads the responses from a given JSON file or from a directory consisting of multiple response JSON files.
 Using further nested directories is also supported.
 
+## Features
+
+- Load static response JSON files (single files or from a directory)
+- Use templates in your responses in the form {slotName} or $slotName (see examples section)
+
 ### Environment Variable
 
 ```
@@ -47,6 +52,43 @@ address:port/nlg
 ```
 {
     "text": "Some text",
+}
+```
+
+# Examples
+
+## Slot Template Filling Example
+
+### Response JSON file
+
+```
+{
+  "example": "This is an example response.",
+  "test": "Test 1 2 3.",
+  "utter_template": "Your number is {number}."
+}
+```
+
+### Request
+
+```
+{
+    "response": "utter_template",
+    "tracker": {
+        "sender_id": "user_42",
+        "slots": {
+            "number": "80"
+        }
+    }
+}
+
+```
+
+### Response
+
+```
+{
+    "text": "Your number is 80."
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'de.kaikarren.nlg'
-version = '0.0.1-SNAPSHOT'
+version = '0.2'
 sourceCompatibility = '11'
 
 repositories {

--- a/src/main/java/de/kaikarren/nlg/Application.java
+++ b/src/main/java/de/kaikarren/nlg/Application.java
@@ -10,8 +10,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 
-import de.kaikarren.Utils;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -68,7 +66,6 @@ public class Application {
         } else {
 
             // the path points to a file
-
             return loadFile(path);
 
         }
@@ -89,8 +86,6 @@ public class Application {
             return new ObjectMapper().readValue(jsonContent,
                     new TypeReference<>() {
                     });
-
-
 
         } catch (IOException e) {
             log.error(e.getMessage());

--- a/src/main/java/de/kaikarren/nlg/Utils.java
+++ b/src/main/java/de/kaikarren/nlg/Utils.java
@@ -1,4 +1,4 @@
-package de.kaikarren;
+package de.kaikarren.nlg;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/main/java/de/kaikarren/nlg/api/NLGRestController.java
+++ b/src/main/java/de/kaikarren/nlg/api/NLGRestController.java
@@ -3,6 +3,7 @@ package de.kaikarren.nlg.api;
 import de.kaikarren.nlg.StaticResponseManager;
 import de.kaikarren.nlg.api.request.NLGRequest;
 import de.kaikarren.nlg.api.response.NLGResponse;
+import de.kaikarren.nlg.generators.TemplateFillingGenerator;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,7 +14,9 @@ public class NLGRestController {
     @PostMapping(path = "/nlg", consumes = "application/json", produces = "application/json")
     public NLGResponse handleRequest(@RequestBody NLGRequest request){
 
-        String responseContent = StaticResponseManager.getInstance().getResponse(request.getResponse());
+        var responseContent = StaticResponseManager.getInstance().getResponse(request.getResponse());
+
+        responseContent = TemplateFillingGenerator.replaceTemplate(responseContent, request.getTracker().getSlots());
 
         NLGResponse nlgResponse = new NLGResponse();
         nlgResponse.setText(responseContent);

--- a/src/main/java/de/kaikarren/nlg/api/request/Slots.java
+++ b/src/main/java/de/kaikarren/nlg/api/request/Slots.java
@@ -30,4 +30,15 @@ public class Slots {
         this.additionalProperties.put(name, value);
     }
 
+    @JsonIgnore
+    public String getSlot(String slotName){
+        var slot = this.additionalProperties.get(slotName);
+
+        if(slot == null){
+            return "";
+        }
+
+        return slot.toString();
+    }
+
 }

--- a/src/main/java/de/kaikarren/nlg/generators/TemplateFillingGenerator.java
+++ b/src/main/java/de/kaikarren/nlg/generators/TemplateFillingGenerator.java
@@ -1,0 +1,96 @@
+package de.kaikarren.nlg.generators;
+
+import de.kaikarren.nlg.api.request.Slots;
+
+public class TemplateFillingGenerator {
+
+    private static final String[] punctuation = {".", ",", "?", "!", ":", ";", "'"};
+
+    public static String replaceTemplate(String response, Slots slots){
+
+        // do not perform the complete processing when it can be negated that there is
+        // a template in the response
+        if(!containsPotentialTemplate(response)){
+            return response;
+        }
+
+        var temp = response;
+
+        // replace punctuations with a whitespace so that also inputs of form
+        // "{name}? Is that correct?" or "$name? Is that correct?" work.
+        temp = replacePunctuation(temp);
+
+        String[] words = temp.split(" ");
+
+        var toReturn = response;
+
+        for (String word : words) {
+
+            // if a word is a single character, no further checks are needed, cannot be a template
+            if (word.length() <= 1) {
+                continue;
+            }
+
+            if (word.startsWith("{") && word.endsWith("}")) {
+
+                word = word.replace("{", "");
+                word = word.replace("}", "");
+
+                var slotValue = slots.getSlot(word);
+
+                if (slotValue == null) {
+                    continue;
+                }
+
+                // replace the template with the value of possible value.
+                toReturn = toReturn.replace("{" + word + "}", slotValue);
+
+            } else if (word.startsWith("$")) {
+
+                word = word.replace("$", "");
+
+                // if the first character of the word after $ is a digit, then
+                // the word is no template because templates cannot start with a digit by definition
+                var firstChar = word.charAt(0);
+                if(Character.isDigit(firstChar)){
+                    continue;
+                }
+
+                var slotValue = slots.getSlot(word);
+
+                if (slotValue == null) {
+                    continue;
+                }
+
+                // replace the template with the value of possible value.
+                toReturn = toReturn.replace("$" + word, slotValue);
+            }
+
+        }
+        return toReturn;
+
+    }
+
+    /**
+     * Replaces the punctuation that could be part of the response
+     * to prevent punctuation to break the slot template filling.
+     * @param response
+     * @return
+     */
+    private static String replacePunctuation(String response){
+
+        for(var punctuation : punctuation){
+            response = response.replace(punctuation, "");
+        }
+
+        return response;
+
+    }
+
+    private static boolean containsPotentialTemplate(String response){
+
+        return response.contains("{") && response.contains("}") || response.contains("$");
+
+    }
+
+}

--- a/src/test/java/de/kaikarren/nlg/generators/TemplateFillingGeneratorTests.java
+++ b/src/test/java/de/kaikarren/nlg/generators/TemplateFillingGeneratorTests.java
@@ -1,0 +1,97 @@
+package de.kaikarren.nlg.generators;
+
+import de.kaikarren.nlg.api.request.Slots;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TemplateFillingGeneratorTests {
+
+    @Test
+    void replaceTemplateSimple() {
+
+        var response = "This is an example for {content} in a response";
+
+        var slots = new Slots();
+        slots.setAdditionalProperty("content", "slot template filling");
+
+        var processedResponse = TemplateFillingGenerator.replaceTemplate(response, slots);
+
+        assertEquals("This is an example for slot template filling in a response", processedResponse);
+
+    }
+
+    @Test
+    void replaceTemplateSimpleDollar() {
+
+        var response = "This is an example for $content in a response";
+
+        var slots = new Slots();
+        slots.setAdditionalProperty("content", "slot template filling");
+
+        var processedResponse = TemplateFillingGenerator.replaceTemplate(response, slots);
+
+        assertEquals("This is an example for slot template filling in a response", processedResponse);
+
+    }
+
+    @Test
+    void doNotReplaceMoney() {
+
+        var response = "This will cost you $45.";
+
+        var slots = new Slots();
+
+        var processedResponse = TemplateFillingGenerator.replaceTemplate(response, slots);
+
+        assertEquals("This will cost you $45.", processedResponse);
+
+    }
+
+    @Test
+    void replaceTemplateComplex() {
+
+        var response = "Hello {example} {number}. {test}. How are you {var2}?";
+
+        var slots = new Slots();
+        slots.setAdditionalProperty("example", "Kai");
+        slots.setAdditionalProperty("number", "42");
+        slots.setAdditionalProperty("test", "This is a test");
+        slots.setAdditionalProperty("var2", "doing");
+
+        var processedResponse = TemplateFillingGenerator.replaceTemplate(response, slots);
+
+        assertEquals("Hello Kai 42. This is a test. How are you doing?", processedResponse);
+
+    }
+
+    @Test
+    void replaceTemplateComplexDollar() {
+
+        var response = "Hello $example $number. $test. How are you $var2?";
+
+        var slots = new Slots();
+        slots.setAdditionalProperty("example", "Kai");
+        slots.setAdditionalProperty("number", "42");
+        slots.setAdditionalProperty("test", "This is a test");
+        slots.setAdditionalProperty("var2", "doing");
+
+        var processedResponse = TemplateFillingGenerator.replaceTemplate(response, slots);
+
+        assertEquals("Hello Kai 42. This is a test. How are you doing?", processedResponse);
+
+    }
+
+    @Test
+    void replaceNothing() {
+
+        var response = "Hello {example $45. {test$. How are you $?";
+
+        var slots = new Slots();
+
+        var processedResponse = TemplateFillingGenerator.replaceTemplate(response, slots);
+
+        assertEquals("Hello {example $45. {test$. How are you $?", processedResponse);
+
+    }
+}


### PR DESCRIPTION
Implemented the support of slot template filling into the responses. So that you can refer slots of your dialogue engine in your static responses with {slotName} or $slotName to add them to your responses at runtime.