### PR TITLE
Added support for randomly selected response variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Using further nested directories is also supported.
 
 - Load static response JSON files (single files or from a directory)
 - Use templates in your responses in the form {slotName} or $slotName (see examples section)
+- Randomly chose a response from a set of given response variations
 
 ### Environment Variable
 
@@ -27,7 +28,11 @@ The responses have to be defined as JSON in the following format
 ```
 {
   "response_name": "This is an example response.",
-  "example_response": "Test 1 2 3."
+  "example_response": "Test 1 2 3.",
+  "response_with_variations": [
+    "first_variation", 
+    "second_variation"
+  ]
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'de.kaikarren.nlg'
-version = '0.2'
+version = '0.3'
 sourceCompatibility = '11'
 
 repositories {

--- a/src/main/java/de/kaikarren/nlg/Application.java
+++ b/src/main/java/de/kaikarren/nlg/Application.java
@@ -43,11 +43,11 @@ public class Application {
 
     }
 
-    public static Map<String, String> load(String path) throws IOException{
+    public static Map<String, Object> load(String path) throws IOException{
 
         // check if the path is a file or a directory
 
-        Map<String, String> nameToResponse = new HashMap<>();
+        Map<String, Object> nameToResponse = new HashMap<>();
 
         if(Files.isDirectory(Path.of(path))){
 
@@ -77,7 +77,7 @@ public class Application {
      * @param fileName The name of the JSON file that should be converted into a Map
      * @return The content of the JSON file as Map<String, String>
      */
-    public static Map<String, String> loadFile(String fileName) {
+    public static Map<String, Object> loadFile(String fileName) {
 
         try {
 

--- a/src/main/java/de/kaikarren/nlg/StaticResponseManager.java
+++ b/src/main/java/de/kaikarren/nlg/StaticResponseManager.java
@@ -3,17 +3,18 @@ package de.kaikarren.nlg;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 
 public class StaticResponseManager {
 
     private static final Logger log = LoggerFactory.getLogger(StaticResponseManager.class);
 
-    private Map<String, String> nameToResponseMapping;
+    private Map<String, Object> nameToResponseMapping;
 
     private static StaticResponseManager staticResponseManager = new StaticResponseManager();
 
-    public void initializeResponses(Map<String, String> nameToResponseMapping){
+    public void initializeResponses(Map<String, Object> nameToResponseMapping){
         this.nameToResponseMapping = nameToResponseMapping;
         StringBuilder sb = new StringBuilder();
         for (String responseName : nameToResponseMapping.keySet()){
@@ -24,11 +25,43 @@ public class StaticResponseManager {
     }
 
     public String getResponse(String responseName){
-        return nameToResponseMapping.get(responseName);
+
+        var responseObject = nameToResponseMapping.get(responseName);
+
+        if(responseObject == null){
+            log.error("No response has been been found for responseName {}", responseName);
+            return "";
+        }
+
+        if(isSingleResponse(responseObject)){
+            return nameToResponseMapping.get(responseName).toString();
+        } else {
+            return getRandomResponse(responseObject);
+        }
+
     }
 
     public static StaticResponseManager getInstance(){
         return staticResponseManager;
+    }
+
+    private boolean isSingleResponse(Object responseObject){
+        return responseObject instanceof String;
+    }
+
+    private String getRandomResponse(Object responseObject){
+
+        if(responseObject instanceof List){
+            @SuppressWarnings("unchecked")
+            var responseList = (List<String>) responseObject;
+
+            return responseList.get(Utils.randomNumber(responseList.size()));
+
+        } else {
+            log.error("Invalid response type {}", responseObject.getClass());
+            return "";
+        }
+
     }
 
 }

--- a/src/main/java/de/kaikarren/nlg/Utils.java
+++ b/src/main/java/de/kaikarren/nlg/Utils.java
@@ -27,4 +27,8 @@ public class Utils {
         }
     }
 
+    public static int randomNumber(int max){
+        return (int) (Math.random() * max);
+    }
+
 }

--- a/src/test/java/de/kaikarren/nlg/StaticResponseManagerTest.java
+++ b/src/test/java/de/kaikarren/nlg/StaticResponseManagerTest.java
@@ -1,0 +1,66 @@
+package de.kaikarren.nlg;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StaticResponseManagerTest {
+
+    @Test
+    void testSimpleResponse() {
+
+        var responses = new HashMap<String, Object>();
+        var expectedResponse = "Welcome, thank you for using our service. How can I help you?";
+
+        responses.put("initial_message", expectedResponse);
+        responses.put("bye", "Goodbye");
+
+        var responseManager = StaticResponseManager.getInstance();
+
+        responseManager.initializeResponses(responses);
+
+        var response = responseManager.getResponse("initial_message");
+
+        assertEquals(expectedResponse, response, "The response is not the the expected one!");
+
+    }
+
+    @Test
+    void testResponseNotFound() {
+
+        var responses = new HashMap<String, Object>();
+        responses.put("bye", "Goodbye");
+
+        var responseManager = StaticResponseManager.getInstance();
+
+        responseManager.initializeResponses(responses);
+
+        var response = responseManager.getResponse("initial_message");
+
+        assertEquals("", response, "The response is not the the expected one!");
+
+    }
+
+    @Test
+    void testRandomSelectFromMultipleResponses() {
+
+        var responses = new HashMap<String, Object>();
+        responses.put("bye", "Goodbye");
+
+        var greet_variations = Arrays.asList("Hey", "Hi", "Hello");
+
+        responses.put("greet", greet_variations);
+
+        var responseManager = StaticResponseManager.getInstance();
+
+        responseManager.initializeResponses(responses);
+
+        var response = responseManager.getResponse("greet");
+
+        assertTrue(greet_variations.contains(response));
+
+    }
+}

--- a/src/test/java/de/kaikarren/nlg/UtilsTest.java
+++ b/src/test/java/de/kaikarren/nlg/UtilsTest.java
@@ -1,0 +1,9 @@
+package de.kaikarren.nlg;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UtilsTest {
+
+}

--- a/test.json
+++ b/test.json
@@ -1,4 +1,7 @@
 {
   "example": "This is an example response.",
-  "test": "Test 1 2 3."
+  "test": "Test 1 2 3.",
+  "greet": [
+    "Hi", "Hello", "Hey"
+  ]
 }


### PR DESCRIPTION
It is now supported to specify n variations of a response from which one will be randomly selected at runtime each time a response for a response/utterance that has different variations is requested.